### PR TITLE
﻿docs: add Ant Group Agentic LLM Trace 2026 dataset

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+traces/*.csv filter=lfs diff=lfs merge=lfs -text

--- a/.github/configs/wordlist.txt
+++ b/.github/configs/wordlist.txt
@@ -40,6 +40,7 @@ json
 jsonl
 kimi
 kondrashov
+lfs
 lifecycle
 llm
 logrus

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ how execution behavior relates to the final outcome.
 - **Make stateful tool execution comparable.** A narrow bridge gives the
 harness temporary access to a persistent task environment while sandbox
 adapters retain control of lifecycle, isolation, and resource observation.
-- **Ground systems research in production behavior. (will be added soon!)** The included
+- **Ground systems research in production behavior.** The included
  [Ant Group Agentic LLM Trace 2026](docs/ant-group-agent-LLM-trace.md) captures
 engine request logs and harness-environment metrics from a real online
 serving workload.
@@ -115,6 +115,15 @@ contact an external model endpoint.
 The DeepSeek example requires an API key and can incur charges. The
 [Quick start](docs/quick-start.md) covers secure credential setup, the first
 run, SGLang alternatives, result inspection, and troubleshooting.
+
+## Trace dataset
+
+The repository includes the [Ant Group Agentic LLM Trace 2026](docs/ant-group-agent-LLM-trace.md)
+under `traces/` — per-pod 24-hour engine logs, a working-hours engine log from
+a randomly selected group of pods, and harness CPU/memory utilization metrics
+collected from Ant Group's production inference infrastructure. The dataset is
+released under [CC-BY-4.0](LICENSE) and is tracked with Git LFS; fetch the
+files after cloning with `git lfs pull`.
 
 ## Research and roadmap
 

--- a/docs/ant-group-agent-LLM-trace-schema.md
+++ b/docs/ant-group-agent-LLM-trace-schema.md
@@ -6,13 +6,22 @@ This document describes the schema and file formats for the [AntGroup Agentic LL
 
 The data is collected from Ant Group's internal API platform, where both agentic and non-agentic workflows can be routed to the same instance. The instances are for internal use only. Since the API platform lacks a clear indicator of whether a harness is used, agentic and non-agentic requests are differentiated based on the input and response content.
 
-One file contains the following fields and covers requests from multiple serving instances during working hours from 10:00 to 18:00, in CSV format: `antgroup_engine_trace_2026.csv`
+The engine trace is provided as CSV files in two groups:
+
+- **Working hours** - `antgroup_engine_trace_2026_working_hours.csv` covers requests during working hours from 10:00 to 18:00 from a group of pods randomly selected from all serving pods. It includes the `pod` field identifying each request's pod. This is the engine-side file used in the [ARIES paper](https://arxiv.org/abs/2607.29069).
+- **24-hour per-pod logs** - `antgroup_engine_trace_2026_24h_1.csv` through `antgroup_engine_trace_2026_24h_5.csv` each record one pod's requests over a 24-hour period (five pods in total). They omit the `pod` field; the pod identity is encoded in the file-name suffix (`1`-`5`) rather than in a column.
+
+> **Notes:**
+> - The working-hours and 24-hour trace sets cover different pod groups and do not overlap.
+> - The 24-hour files span a full calendar day, from 00:00 to 23:59.
+> - The working-hours file comprises 10 pods in total.
+> - Due to imperfections in the upstream data source, some data points may be missing; consumers should account for empty values when processing the data.
 
 ### Schema
 
 | Field                 | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| pod                   | Label of the pod (virtual environment) that served the request |
+| pod                   | Label of the pod (virtual environment) that served the request; present only in `antgroup_engine_trace_2026_working_hours.csv` (the 24-hour files identify their pod by file-name suffix `1`-`5`) |
 | emit_time             | Timestamp of the log record, expressed as a relative time    |
 | actual_hit_ratio      | Actual prefix-cache hit ratio of the request                 |
 | check_pass            | Whether the request completed successfully                   |
@@ -39,6 +48,10 @@ The harness side is a variant of OpenClaw used internally for tasks such as offi
 
 > **Note:** The engine-side and harness-side data are not from the same period and production environment, so they are not directly relatable.
 
-One file contains CPU and memory utilization data for 100 pods, collected over a 24-hour period, in CSV format: `antgroup_harness_cpu_utilization_2026.csv` and `antgroup_harness_memory_utilization_2026.csv`
+CPU and memory utilization for 100 pods, collected over a 24-hour period, are provided as CSV files: `antgroup_harness_cpu_utilization_2026_24h.csv` and `antgroup_harness_memory_utilization_2026_24h.csv`
 
 Each file contains 100 columns, one per pod. Columns follow the pattern `[Metric](pod=[pod name])`, where `Metric` is `cpu_util` or `mem_util`.
+
+> **Notes:**
+> - Utilization values are expressed as percentages of allocation (%).
+> - Harness pods are not necessarily active for the full 24-hour period; utilization is recorded only over each pod's lifespan.

--- a/docs/ant-group-agent-LLM-trace.md
+++ b/docs/ant-group-agent-LLM-trace.md
@@ -6,22 +6,55 @@ This dataset captures a portion of the online serving workload from Ant Group's 
 
 The trace records requests served by an LLM engine along with the resource utilization of the virtual environments (pods) in which the agents execute. The data spans cache behavior (hit ratio and cached token length), request lifecycle metrics (TTFT, TPOT, prefill time, end-to-end latency, and queue length), engine state (batch size and context length), token statistics (input, output, and total token lengths), and pod-level CPU and memory utilization.
 
-The harness-side records contain 24 hours of data, while the engine-side records capture requests from multiple serving instances during working hours.
+The harness-side records contain 24 hours of data, while the engine-side records capture requests from five individual pods over 24 hours each, and from a separate group of pods, randomly sampled from all serving pods during working hours (10:00-18:00). The working-hours pods are a different group and are not the same pods as those in the 24-hour records.
 
 The dataset consists of this description and the following sets of files:
 
 - LLM Engine request logs
 - Harness environment metrics
 
+## Files
+
+The data files ship in the repository under `traces/` and are tracked with
+[Git LFS](https://git-lfs.com/).
+
+| File | Contents | Rows |
+| --- | --- | --- |
+| `antgroup_engine_trace_2026_24h_1.csv` | Engine request log, pod 1, 24 hours | 14,836 |
+| `antgroup_engine_trace_2026_24h_2.csv` | Engine request log, pod 2, 24 hours | 12,257 |
+| `antgroup_engine_trace_2026_24h_3.csv` | Engine request log, pod 3, 24 hours | 18,066 |
+| `antgroup_engine_trace_2026_24h_4.csv` | Engine request log, pod 4, 24 hours | 7,580 |
+| `antgroup_engine_trace_2026_24h_5.csv` | Engine request log, pod 5, 24 hours | 13,650 |
+| `antgroup_engine_trace_2026_working_hours.csv` | Engine request log, randomly selected pods, working hours | 33,986 |
+| `antgroup_harness_cpu_utilization_2026_24h.csv` | CPU utilization, 100 pods, 24 hours | 1,440 |
+| `antgroup_harness_memory_utilization_2026_24h.csv` | Memory utilization, 100 pods, 24 hours | 1,440 |
+
+Each `antgroup_engine_trace_2026_24h_*.csv` file records one pod's requests
+over a 24-hour period; the pod identity is encoded in the file-name suffix
+(`1`-`5`) rather than in a column. The working-hours file covers a different
+group of pods randomly selected from all serving pods and includes a `pod`
+column identifying each request's pod.
+
+`antgroup_engine_trace_2026_working_hours.csv` is the engine-side file used in
+the [ARIES paper](https://arxiv.org/abs/2607.29069).
+
 ## Using the Data
 
 ### License
 
-TBD
+The trace dataset is released under the
+[Creative Commons Attribution 4.0 International (CC-BY-4.0)](../LICENSE) license.
 
 ### Downloading
 
-The dataset can be downloaded at: TBD
+The dataset is included in this repository under `traces/` and is stored with
+Git LFS. After cloning the repository, fetch the trace files with:
+
+```sh
+git lfs pull
+```
+
+A separate standalone download location will be published at a later date.
 
 ### Schema
 

--- a/traces/antgroup_engine_trace_2026_24h_1.csv
+++ b/traces/antgroup_engine_trace_2026_24h_1.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:893498030c218fe65770d0dbb02212a27c968e4016ed8caa5fc10d91f9090aaf
+size 2197931

--- a/traces/antgroup_engine_trace_2026_24h_2.csv
+++ b/traces/antgroup_engine_trace_2026_24h_2.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ba0ca057ff360509813d3f8d6a31005a6dc8ccff8b315fbe4c21ee503abbb7c
+size 1812815

--- a/traces/antgroup_engine_trace_2026_24h_3.csv
+++ b/traces/antgroup_engine_trace_2026_24h_3.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4da83ca5a6fa3d40e8a76f8a9ee48767b08619da8025bb2aaf5f1c7310df3547
+size 2753615

--- a/traces/antgroup_engine_trace_2026_24h_4.csv
+++ b/traces/antgroup_engine_trace_2026_24h_4.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2142aa52b3f52d9697d7dc7f38b8604748ad740c7cc392f344df575dd4ea881
+size 1126088

--- a/traces/antgroup_engine_trace_2026_24h_5.csv
+++ b/traces/antgroup_engine_trace_2026_24h_5.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d86ebf32940ee43ab3703ddfa2ac3442c6152ddef4ec1a1ba88312db398d2801
+size 2024577

--- a/traces/antgroup_engine_trace_2026_working_hours.csv
+++ b/traces/antgroup_engine_trace_2026_working_hours.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0dc672d3c018aab142de4adffb5e9907f119e1e0869ed3625d4c3355d0f42302
+size 5660631

--- a/traces/antgroup_harness_cpu_utilization_2026_24h.csv
+++ b/traces/antgroup_harness_cpu_utilization_2026_24h.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:884babe94f93c3b901946e975c3c2a92b91058c6f5c8e3d3fba31a6dc05c8a9b
+size 586153

--- a/traces/antgroup_harness_memory_utilization_2026_24h.csv
+++ b/traces/antgroup_harness_memory_utilization_2026_24h.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f2e19b244722b0b83e6113bf38b4c7393d1bd89e823f70c95fc80602630ff2b
+size 571088


### PR DESCRIPTION
Track the Ant Group engine and harness trace CSVs with Git LFS and document them in README and docs: five per-pod 24-hour engine logs, a working-hours engine log across a randomly selected group of pods, and harness CPU/memory utilization. Correct the schema file names and the CC-BY-4.0 license pointer.

## Summary

Add the [Ant Group Agentic LLM Trace 2026](docs/ant-group-agent-LLM-trace.md) dataset to the repository under `traces/`, tracked with Git LFS, and document it in the README and the trace docs (file inventory, schema, license, and download instructions).

## Implementation Notes :hammer_and_pick:

* Added a `traces/*.csv` LFS tracking rule in `.gitattributes`, so the ~16 MB of CSV data is stored as Git LFS pointers instead of bloating the Git history; a plain clone yields placeholders until `git lfs pull`.
* Added 8 trace files:
  - Five per-pod 24-hour engine request logs (`antgroup_engine_trace_2026_24h_1.csv` … `_5.csv`), one file per pod; the pod identity is encoded in the file-name suffix, not in a column.
  - One working-hours engine log (`antgroup_engine_trace_2026_working_hours.csv`) across a group of pods randomly selected from all serving pods, with a `pod` column. This is the engine-side file used in the ARIES paper.
  - Harness CPU and memory utilization for 100 pods over 24 hours (`antgroup_harness_cpu_utilization_2026_24h.csv`, `antgroup_harness_memory_utilization_2026_24h.csv`).
* `docs/ant-group-agent-LLM-trace.md`: file inventory with row counts, CC-BY-4.0 license pointer, and `git lfs pull` download instructions.
* `docs/ant-group-agent-LLM-trace-schema.md`: corrected file names and documented the two engine-trace groups and the `pod` field scope.
* `README.md`: linked the dataset from "Why ARIES" and added a "Trace dataset" section.
* Reviewer talking points: the working-hours file is the dataset used in the paper; the 24-hour pods and the working-hours pods are different groups; reviewers need Git LFS installed to fetch the actual data.

## External Dependencies :four_leaf_clover:

* Git LFS (needed to clone/fetch the trace data). No Go or runtime dependencies added.

## Breaking API Changes :warning:

* N/A — documentation- and data-only change; no code, config, or runtime behavior changes.

## Issues that this PR closes

* Closes [hyscale-lab/ARIES#38](https://github.com/hyscale-lab/ARIES/issues/38) — [[Feature]: Provide Ant Group trace link for ARIES project]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Ant Group production trace dataset.
  * Added separate 24-hour and working-hours engine datasets with documented inventories and pod identification details.
  * Made the dataset available under the CC-BY-4.0 license.

* **Documentation**
  * Added Git LFS instructions for retrieving trace files.
  * Clarified sampling, pod coverage, storage details, row counts, missing values, and metric filenames.
  * Linked the working-hours trace to the ARIES paper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->