### PR TITLE
feat(runtime): add a generic external openai backend

### DIFF
--- a/.agents/DESIGN.md
+++ b/.agents/DESIGN.md
@@ -51,7 +51,9 @@ lifecycle. SGLang is the current implementation of this rule.
 
 Model selection is explicit through `runtime.backend`: `deepseek` retains its
 official bounded preflight, while `sglang` performs bounded exact model
-discovery at a versioned `/v1` endpoint. A local SGLang profile references one
+discovery at a versioned `/v1` endpoint. `openai` names any other
+OpenAI-compatible server, is external only, carries no native file, and shares
+that discovery. A local SGLang profile references one
 strict native YAML file under `runtime.config.file`, whose
 served model and port must match the profile. SGLang may remain external or run
 as one application-owned host process supplied by an explicit command switch.

--- a/.agents/DESIGN.md
+++ b/.agents/DESIGN.md
@@ -49,11 +49,13 @@ Backend-specific resolution supplies the same effective list to runtime
 construction and NVIDIA sampling without changing the Runner or Recorder
 lifecycle. SGLang is the current implementation of this rule.
 
-Model selection is explicit through `runtime.backend`: `deepseek` retains its
-official bounded preflight, while `sglang` performs bounded exact model
-discovery at a versioned `/v1` endpoint. `openai` names any other
-OpenAI-compatible server, is external only, carries no native file, and shares
-that discovery. A local SGLang profile references one
+Ownership is explicit through `runtime.mode`: every external endpoint is
+prepared the same way, and only managed mode names a runtime ARIES prepares.
+Model selection is explicit through `runtime.backend`, which names the kind of
+service behind the endpoint: `deepseek` retains its official bounded preflight,
+while `sglang` performs bounded exact model discovery at a versioned `/v1`
+endpoint. `openai` names any other OpenAI-compatible server, is external only,
+carries no native file, and shares that discovery. A local SGLang profile references one
 strict native YAML file under `runtime.config.file`, whose
 served model and port must match the profile. SGLang may remain external or run
 as one application-owned host process supplied by an explicit command switch.

--- a/.agents/DESIGN.md
+++ b/.agents/DESIGN.md
@@ -57,7 +57,8 @@ while `sglang` performs bounded exact model discovery at a versioned `/v1`
 endpoint. `openai` names any other OpenAI-compatible server, is external only,
 carries no native file, and shares that discovery. A local SGLang profile references one
 strict native YAML file under `runtime.config.file`, whose
-served model and port must match the profile. SGLang may remain external or run
+served model and port must match the profile. External SGLang needs no native file; an optional legacy file reference is not
+read or validated. SGLang may remain external or run
 as one application-owned host process supplied by an explicit command switch.
 The general runtime lifecycle/health interface is separate from inference and
 is not a fifth Runner role. Neither provider stores key bytes in profiles or

--- a/.agents/TASKS.md
+++ b/.agents/TASKS.md
@@ -1,5 +1,17 @@
 # ARIES Tasks
 
+## PR #50 — External SGLang review correction
+
+- Removed the native launch-file requirement from external SGLang profile
+  validation and preparation; retained managed configuration and external
+  ownership checks. Existing optional external file references remain accepted
+  but are not opened. Added decode and no-side-effect preparation regressions.
+- Build, unit, race, and lint checks pass. All integration packages except
+  SWE-bench Pro pass. That fixture initially lacked Git LFS; an ignored local
+  official Git LFS installation still leaves the pinned Parquet as an LFS
+  pointer, so the dataset integration remains an explicit environment gap.
+- Final Docker inspection found no ARIES containers or networks.
+
 ## R22 — Public SWE-bench Pro benchmark adapter
 
 1. [x] Pin the public dataset and official open-source evaluator independently,

--- a/.github/configs/lychee.toml
+++ b/.github/configs/lychee.toml
@@ -4,6 +4,7 @@ exclude = [
     '^http://localhost(:[0-9]+)?(/|$)',
     '^http://127\.0\.0\.1(:[0-9]+)?(/|$)',
     '^http://sglang\.local(:[0-9]+)?(/|$)',
+    '^http://vllm\.local(:[0-9]+)?(/|$)',
     '^https://api\.deepseek\.com/?$',
     'https://github.com/orgs/hyscale-lab/projects/7',
 ]

--- a/.github/configs/wordlist.txt
+++ b/.github/configs/wordlist.txt
@@ -58,8 +58,8 @@ moe
 NCSpeech
 nousresearch
 ntu
-OAuth
 nvidia
+OAuth
 oci
 openai
 openclaw
@@ -73,12 +73,13 @@ pre
 prefill
 preflight
 preload
-Qwen
 prewarm
+Qwen
 Realtime
 reflogs
 reimplement
 relicense
+renderer
 replayable
 roadmap
 runnable
@@ -124,6 +125,7 @@ utf
 uuid
 validator
 verifier
+vllm
 websocket
 workdir
 workdirs

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ implementations:
 | Benchmark | Terminal-Bench 2; Deep Research Bench; the 731-task public SWE-bench Pro split |
 | Tool sandbox | Docker, using the Moby Go SDK |
 | Tool bridge | OpenClaw–Docker SSH bridge; Hermes–Docker SSH bridge |
-| Model service | External DeepSeek; external or ARIES-managed SGLang |
+| Model service | External DeepSeek; external OpenAI-compatible servers such as vLLM; external or ARIES-managed SGLang |
 
 See [Supported implementations](docs/supported.md) for ownership,
 configuration keys, status, and runnable profiles. ARIES uses explicit

--- a/cmd/aries/wiring.go
+++ b/cmd/aries/wiring.go
@@ -91,6 +91,14 @@ func prepareBackend(cfg config.Config, outputDir string) (app.PreparedBackend, e
 			return app.PreparedBackend{}, errors.New("DeepSeek runtime must be external")
 		}
 		return app.PreparedBackend{Model: model}, nil
+	case "openai":
+		// Any OpenAI-compatible server. ARIES validates the endpoint in
+		// preflight and never owns the process, so there is nothing to
+		// prepare beyond the model description.
+		if cfg.Runtime.Mode != "external" {
+			return app.PreparedBackend{}, errors.New("OpenAI-compatible runtime must be external")
+		}
+		return app.PreparedBackend{Model: model}, nil
 	case "sglang":
 		native, err := runtimesglang.LoadNativeConfig(cfg.Runtime.Config.ResolvedFile, cfg.Model.ID, cfg.Model.BaseURL)
 		if err != nil {

--- a/cmd/aries/wiring.go
+++ b/cmd/aries/wiring.go
@@ -88,8 +88,7 @@ func validateComponents(cfg config.Config) error {
 // runtime.mode is the ownership distinction: every external endpoint is
 // prepared the same way, whatever serves it. runtime.backend names the kind of
 // service behind the endpoint, which selects the preflight and the harness's
-// provider mapping downstream; here it only decides whether a native file must
-// agree with the profile.
+// provider mapping downstream. Only managed SGLang loads a native launch file.
 func prepareBackend(cfg config.Config, outputDir string) (app.PreparedBackend, error) {
 	model := cfg.CoreModel()
 	switch cfg.Runtime.Mode {
@@ -98,9 +97,6 @@ func prepareBackend(cfg config.Config, outputDir string) (app.PreparedBackend, e
 		case "deepseek":
 		case "openai":
 		case "sglang":
-			if _, err := runtimesglang.LoadNativeConfig(cfg.Runtime.Config.ResolvedFile, cfg.Model.ID, cfg.Model.BaseURL); err != nil {
-				return app.PreparedBackend{}, err
-			}
 		default:
 			return app.PreparedBackend{}, fmt.Errorf("unsupported model runtime backend %q", cfg.Runtime.Backend)
 		}

--- a/cmd/aries/wiring.go
+++ b/cmd/aries/wiring.go
@@ -83,45 +83,47 @@ func validateComponents(cfg config.Config) error {
 	return nil
 }
 
+// prepareBackend turns the profile's runtime block into the model the harness
+// receives and, for managed SGLang only, the host process ARIES owns.
+// runtime.mode is the ownership distinction: every external endpoint is
+// prepared the same way, whatever serves it. runtime.backend names the kind of
+// service behind the endpoint, which selects the preflight and the harness's
+// provider mapping downstream; here it only decides whether a native file must
+// agree with the profile.
 func prepareBackend(cfg config.Config, outputDir string) (app.PreparedBackend, error) {
 	model := cfg.CoreModel()
-	switch cfg.Runtime.Backend {
-	case "deepseek":
-		if cfg.Runtime.Mode != "external" {
-			return app.PreparedBackend{}, errors.New("DeepSeek runtime must be external")
+	switch cfg.Runtime.Mode {
+	case "external":
+		switch cfg.Runtime.Backend {
+		case "deepseek":
+		case "openai":
+		case "sglang":
+			if _, err := runtimesglang.LoadNativeConfig(cfg.Runtime.Config.ResolvedFile, cfg.Model.ID, cfg.Model.BaseURL); err != nil {
+				return app.PreparedBackend{}, err
+			}
+		default:
+			return app.PreparedBackend{}, fmt.Errorf("unsupported model runtime backend %q", cfg.Runtime.Backend)
 		}
 		return app.PreparedBackend{Model: model}, nil
-	case "openai":
-		// Any OpenAI-compatible server. ARIES validates the endpoint in
-		// preflight and never owns the process, so there is nothing to
-		// prepare beyond the model description.
-		if cfg.Runtime.Mode != "external" {
-			return app.PreparedBackend{}, errors.New("OpenAI-compatible runtime must be external")
+	case "managed":
+		if cfg.Runtime.Backend != "sglang" {
+			return app.PreparedBackend{}, fmt.Errorf("runtime.backend %q must be external", cfg.Runtime.Backend)
 		}
-		return app.PreparedBackend{Model: model}, nil
-	case "sglang":
 		native, err := runtimesglang.LoadNativeConfig(cfg.Runtime.Config.ResolvedFile, cfg.Model.ID, cfg.Model.BaseURL)
 		if err != nil {
 			return app.PreparedBackend{}, err
 		}
-		switch cfg.Runtime.Mode {
-		case "external":
-			return app.PreparedBackend{Model: model}, nil
-		case "managed":
-			gpuIndices, err := native.ResolveGPUIndices(cfg.Runtime.Config.GPUIndices)
-			if err != nil {
-				return app.PreparedBackend{}, fmt.Errorf("resolve managed SGLang GPUs: %w", err)
-			}
-			runtime, err := runtimesglang.New(runtimesglang.Options{Executable: cfg.Runtime.Config.Executable, ConfigPath: cfg.Runtime.Config.ResolvedFile, OutputDir: outputDir, BaseURL: cfg.Model.BaseURL, CredentialEnv: cfg.Model.APIKeyEnv, GPUIndices: append([]int(nil), gpuIndices...)})
-			if err != nil {
-				return app.PreparedBackend{}, err
-			}
-			return app.PreparedBackend{Model: model, Runtime: runtime, EffectiveGPUIndices: append([]int(nil), gpuIndices...)}, nil
-		default:
-			return app.PreparedBackend{}, fmt.Errorf("unsupported SGLang runtime mode %q", cfg.Runtime.Mode)
+		gpuIndices, err := native.ResolveGPUIndices(cfg.Runtime.Config.GPUIndices)
+		if err != nil {
+			return app.PreparedBackend{}, fmt.Errorf("resolve managed SGLang GPUs: %w", err)
 		}
+		runtime, err := runtimesglang.New(runtimesglang.Options{Executable: cfg.Runtime.Config.Executable, ConfigPath: cfg.Runtime.Config.ResolvedFile, OutputDir: outputDir, BaseURL: cfg.Model.BaseURL, CredentialEnv: cfg.Model.APIKeyEnv, GPUIndices: append([]int(nil), gpuIndices...)})
+		if err != nil {
+			return app.PreparedBackend{}, err
+		}
+		return app.PreparedBackend{Model: model, Runtime: runtime, EffectiveGPUIndices: append([]int(nil), gpuIndices...)}, nil
 	default:
-		return app.PreparedBackend{}, fmt.Errorf("unsupported model runtime backend %q", cfg.Runtime.Backend)
+		return app.PreparedBackend{}, fmt.Errorf("unsupported model runtime mode %q", cfg.Runtime.Mode)
 	}
 }
 

--- a/cmd/aries/wiring_test.go
+++ b/cmd/aries/wiring_test.go
@@ -74,7 +74,7 @@ func TestExplicitCompositionSwitches(t *testing.T) {
 		t.Fatal(err)
 	}
 	text := string(source)
-	for _, value := range []string{`case "terminalbench2"`, `case "swebenchpro"`, `case "openclaw"`, `case "hermes"`, `case "docker"`, `case "openclaw-ssh"`, `case "hermes-ssh"`, `case "deepseek"`, `case "sglang"`} {
+	for _, value := range []string{`case "terminalbench2"`, `case "swebenchpro"`, `case "openclaw"`, `case "hermes"`, `case "docker"`, `case "openclaw-ssh"`, `case "hermes-ssh"`, `case "deepseek"`, `case "sglang"`, `case "openai"`} {
 		if !strings.Contains(text, value) {
 			t.Fatalf("missing explicit switch %s", value)
 		}
@@ -346,3 +346,18 @@ mem-fraction-static: 0.85
 reasoning-parser: qwen3
 tool-call-parser: qwen
 `
+
+func TestExternalOpenAIPreparationReturnsNilRuntime(t *testing.T) {
+	cfg := config.Config{Runtime: config.RuntimeConfig{Backend: "openai", Mode: "external"}, Model: config.ProfileModel{ID: "served/model", BaseURL: "http://vllm.local:8000/v1", APIKeyEnv: "KEY"}}
+	prepared, err := prepareBackend(cfg, filepath.Join(t.TempDir(), "absent"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prepared.Runtime != nil || prepared.Model.Provider != "openai" || len(prepared.EffectiveGPUIndices) != 0 {
+		t.Fatalf("prepared=%#v", prepared)
+	}
+	cfg.Runtime.Mode = "managed"
+	if _, err := prepareBackend(cfg, t.TempDir()); err == nil {
+		t.Fatal("managed OpenAI-compatible runtime was accepted")
+	}
+}

--- a/cmd/aries/wiring_test.go
+++ b/cmd/aries/wiring_test.go
@@ -176,11 +176,7 @@ func TestMakeLintIncludesInternalPackages(t *testing.T) {
 
 func TestExternalSGLangPreparationReturnsNilRuntime(t *testing.T) {
 	root := t.TempDir()
-	native := filepath.Join(root, "native.yaml")
-	if err := os.WriteFile(native, []byte(nativeForWiring), 0600); err != nil {
-		t.Fatal(err)
-	}
-	cfg := config.Config{Runtime: config.RuntimeConfig{Backend: "sglang", Mode: "external", Config: config.RuntimeConfigValues{ResolvedFile: native}}, Model: config.ProfileModel{ID: "Qwen/Qwen3-8B", BaseURL: "http://host:30000/v1", APIKeyEnv: "KEY"}}
+	cfg := config.Config{Runtime: config.RuntimeConfig{Backend: "sglang", Mode: "external"}, Model: config.ProfileModel{ID: "Qwen/Qwen3-8B", BaseURL: "http://host:30000/v1", APIKeyEnv: "KEY"}}
 	prepared, err := prepareBackend(cfg, filepath.Join(root, "absent"))
 	if err != nil {
 		t.Fatal(err)

--- a/docs/design/harness.md
+++ b/docs/design/harness.md
@@ -87,6 +87,13 @@ regardless of ownership.
 Second, Hermes requires `/bin/bash` in the task image, because every tool call
 it issues is `bash -c` on the remote.
 
+Third, Hermes accepts only provider names in its own registry, and the one-shot
+rejects an unknown name before any request. Neither pinned version knows
+`sglang` or a plain `openai` provider, so the renderer maps both backends to
+Hermes's generic `custom` provider, which routes to `model.base_url`, in the
+rendered config and in the one-shot's `--provider` argument. DeepSeek is a
+built-in provider and stays as written.
+
 ## Customization & Contribution Guide
 
 Add a harness only when it can implement the existing `AgentHarness` lifecycle

--- a/docs/design/runtime.md
+++ b/docs/design/runtime.md
@@ -12,7 +12,7 @@ variable. ARIES validates the endpoint before admitting task work.
 
 ```mermaid
 flowchart TB
-    X[External DeepSeek or SGLang]
+    X[External DeepSeek, SGLang, or OpenAI-compatible server]
     M[ARIES-managed SGLang process]
     E[Validated model endpoint]
 
@@ -28,8 +28,11 @@ flowchart TB
 ```
 
 DeepSeek is supported only as an external OpenAI-compatible endpoint. ARIES
-performs bounded model validation but does not own the remote service. SGLang
-may also be external, or ARIES may manage one host process across a profile run.
+performs bounded model validation but does not own the remote service. The
+`openai` backend names any other OpenAI-compatible server, such as vLLM; it is
+external only, has no native configuration file, and receives the same bounded
+model discovery as external SGLang. SGLang may also be external, or ARIES may
+manage one host process across a profile run.
 Managed SGLang uses a native YAML file, explicit executable and timeouts, and
 optional GPU indices; ARIES validates model, port, and GPU topology before side
 effects and stops the owned process after admitted tasks drain.

--- a/docs/design/runtime.md
+++ b/docs/design/runtime.md
@@ -8,7 +8,11 @@ four component roles and is not a fifth Runner role.
 
 Profiles select `runtime.backend` and `runtime.mode`, while model configuration
 identifies the endpoint, served model, and name of the credential environment
-variable. ARIES validates the endpoint before admitting task work.
+variable. The mode is the ownership distinction: every external endpoint is
+prepared the same way, whatever serves it, and only a managed process is a
+runtime ARIES prepares. The backend names the kind of service behind the
+endpoint and selects its preflight and the provider each harness renders.
+ARIES validates the endpoint before admitting task work.
 
 ```mermaid
 flowchart TB
@@ -29,10 +33,11 @@ flowchart TB
 
 DeepSeek is supported only as an external OpenAI-compatible endpoint. ARIES
 performs bounded model validation but does not own the remote service. The
-`openai` backend names any other OpenAI-compatible server, such as vLLM; it is
-external only, has no native configuration file, and receives the same bounded
-model discovery as external SGLang. SGLang may also be external, or ARIES may
-manage one host process across a profile run.
+`openai` backend names any other OpenAI-compatible server, such as vLLM. It
+describes the endpoint's API rather than a distinct runtime: it is external
+only, has no native configuration file, adds no preparation step, and receives
+the same bounded model discovery as external SGLang. SGLang may also be
+external, or ARIES may manage one host process across a profile run.
 Managed SGLang uses a native YAML file, explicit executable and timeouts, and
 optional GPU indices; ARIES validates model, port, and GPU topology before side
 effects and stops the owned process after admitted tasks drain.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -102,8 +102,9 @@ ARIES owns a model-server process. The supported combinations are:
 | `deepseek` | `external` | Must be omitted | DeepSeek |
 | `sglang` | `external` | `file` only | User |
 | `sglang` | `managed` | `file`, `executable`, `startup_timeout`, `stop_timeout` | ARIES |
+| `openai` | `external` | Must be omitted | User |
 
-DeepSeek cannot use managed mode. SGLang supports both modes.
+DeepSeek and `openai` are external only. SGLang supports both modes.
 
 ### External DeepSeek
 
@@ -205,6 +206,51 @@ credential:
 export SGLANG_API_KEY=unused-local-token
 ./bin/aries .cache/openclaw-tb2-fix-git-sglang.json
 ```
+
+### External OpenAI-compatible server
+
+`runtime.backend: "openai"` accepts any server that speaks the OpenAI chat
+completions API and lists its models at `/v1/models`: vLLM, `llama.cpp`, a
+gateway, or a hosted endpoint. ARIES never starts, configures, or stops the
+server. Before the run it makes one bounded `/v1/models` request and confirms
+that `model.id` is served. `runtime.config` must be omitted.
+
+The checked-in profile targets a vLLM server:
+
+```json
+{
+  "runtime": {
+    "backend": "openai",
+    "mode": "external"
+  },
+  "model": {
+    "base_url": "http://vllm.local:8000/v1",
+    "api_key_env": "VLLM_API_KEY",
+    "id": "Qwen/Qwen3.6-35B-A3B-FP8"
+  }
+}
+```
+
+Copy the profile, then set `model.base_url` to an HTTP endpoint that ends
+exactly in `/v1` and `model.id` to the name the server reports. The
+`vllm.local` hostname is a placeholder; the address must resolve from the ARIES
+host and from the harness containers. Start the server yourself, for example:
+
+```sh
+vllm serve Qwen/Qwen3.6-35B-A3B-FP8 --port 8000 \
+  --served-model-name Qwen/Qwen3.6-35B-A3B-FP8
+```
+
+An unauthenticated server still needs a nonempty placeholder credential:
+
+```sh
+export VLLM_API_KEY=unused-local-token
+./bin/aries profiles/hermes-tb2-fix-git-vllm.json
+```
+
+Hermes has no `sglang` or plain `openai` provider, so for both backends ARIES
+renders Hermes's generic `custom` provider, which routes to `model.base_url`.
+OpenClaw receives the server as a `models.providers` entry named `aries`.
 
 ### Managed SGLang
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -94,8 +94,12 @@ task's `task.toml`; no version-catalog or Go code change is required.
 
 ## 3. Configure the model backend
 
-`runtime.backend` selects the provider, while `runtime.mode` states whether
-ARIES owns a model-server process. The supported combinations are:
+`runtime.mode` states whether ARIES owns a model-server process: an `external`
+endpoint is validated but never started, configured, or stopped, and a
+`managed` process is owned for the run. `runtime.backend` names the kind of
+service behind the endpoint, which selects the preflight and the provider each
+harness renders; it is not a runtime ARIES prepares. The supported combinations
+are:
 
 | Backend | Mode | `runtime.config` | Process owner |
 | --- | --- | --- | --- |

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -190,7 +190,8 @@ The checked-in profile uses the following external runtime and model settings:
 }
 ```
 
-External SGLang mode accepts only `runtime.config.file`; `executable`,
+External SGLang mode needs no `runtime.config`. An optional `config.file` is
+accepted for existing profiles but is not read or validated; `executable`,
 `startup_timeout`, and `stop_timeout` are rejected because ARIES does not own
 that process. Start SGLang separately; for example, this exposes GPU0 to the
 server:

--- a/docs/supported.md
+++ b/docs/supported.md
@@ -16,6 +16,7 @@ plugin discovery.
 | Tool bridge | **Hermes SSH** — pair-specific bridge for Hermes | Same ownership; accepts Hermes's own SSH grammar and denies its `~/.hermes` file sync | `bridge.type: "hermes-ssh"`; requires `harness.type: "hermes"`; needs no helper binary because Hermes runs OpenSSH itself |
 | Model service | **DeepSeek** — supported external OpenAI-compatible endpoint | Validates model access; does not own the service | `runtime.backend: "deepseek"`, `runtime.mode: "external"`; `profiles/openclaw-tb2-fix-git-deepseek.json` |
 | Model service | **SGLang** — supported external or ARIES-managed runtime | Validates both modes; in managed mode owns one host process for the profile run | `runtime.backend: "sglang"`; `profiles/openclaw-tb2-fix-git-sglang.json`; `configs/sglang/qwen3-8b-local.yaml` |
+| Model service | **OpenAI-compatible server** — external only; vLLM, `llama.cpp`, gateways, hosted endpoints | Confirms the served model through one bounded `/v1/models` request; never starts, configures, or stops the server | `runtime.backend: "openai"`, `runtime.mode: "external"`; `profiles/hermes-tb2-fix-git-vllm.json` |
 
 ## Configuration boundaries
 
@@ -33,8 +34,9 @@ issues is `bash -c` on the remote.
 Model services sit outside the four-role Runner. DeepSeek must be external and uses the
 configured remote base URL. SGLang accepts an external endpoint backed by its
 native YAML, or a managed mode with an explicit Python executable, startup and
-stop timeouts, and optional validated GPU indices. DeepSeek is not a managed
-runtime, and SGLang is not a fifth Runner role.
+stop timeouts, and optional validated GPU indices. The `openai` backend is any
+other OpenAI-compatible server; it is external only and has no native file.
+DeepSeek is not a managed runtime, and SGLang is not a fifth Runner role.
 
 Realtime mode requires `harness.realtime` TTS and session settings and the
 separate `OPENAI_API_KEY` named by `harness.realtime.tts.api_key_env`. The TTS
@@ -48,6 +50,7 @@ Start with one of the checked-in profiles:
 - `profiles/openclaw-tb2-fix-git-sglang.json`
 - `profiles/openclaw-tb2-fix-git-realtime-deepseek.json`
 - `profiles/hermes-tb2-fix-git-deepseek.json`
+- `profiles/hermes-tb2-fix-git-vllm.json` — the same run against an external vLLM server through the `openai` backend
 - `profiles/openclaw-drb-smoke1-deepseek.json` — Deep Research Bench, DeepSeek harness model, DeepSeek judge model, web search with Tavily extract
 - `profiles/openclaw-drb-smoke3-deepseek.json` — Deep Research Bench, larger task subset, web search with Tavily extract
 - `profiles/hermes-drb-smoke1-deepseek.json` — Deep Research Bench, Hermes harness with web search and Tavily extract

--- a/docs/supported.md
+++ b/docs/supported.md
@@ -32,8 +32,8 @@ additionally requires `/bin/bash` in the task image, because every tool call it
 issues is `bash -c` on the remote.
 
 Model services sit outside the four-role Runner. DeepSeek must be external and uses the
-configured remote base URL. SGLang accepts an external endpoint backed by its
-native YAML, or a managed mode with an explicit Python executable, startup and
+configured remote base URL. SGLang accepts an external endpoint without a local
+launch file, or a managed mode with an explicit Python executable, startup and
 stop timeouts, and optional validated GPU indices. The `openai` backend is any
 other OpenAI-compatible server; it names the endpoint's API rather than a
 runtime ARIES prepares, is external only, and has no native file. DeepSeek is

--- a/docs/supported.md
+++ b/docs/supported.md
@@ -35,8 +35,9 @@ Model services sit outside the four-role Runner. DeepSeek must be external and u
 configured remote base URL. SGLang accepts an external endpoint backed by its
 native YAML, or a managed mode with an explicit Python executable, startup and
 stop timeouts, and optional validated GPU indices. The `openai` backend is any
-other OpenAI-compatible server; it is external only and has no native file.
-DeepSeek is not a managed runtime, and SGLang is not a fifth Runner role.
+other OpenAI-compatible server; it names the endpoint's API rather than a
+runtime ARIES prepares, is external only, and has no native file. DeepSeek is
+not a managed runtime, and SGLang is not a fifth Runner role.
 
 Realtime mode requires `harness.realtime` TTS and session settings and the
 separate `OPENAI_API_KEY` named by `harness.realtime.tts.api_key_env`. The TTS

--- a/internal/app/preflight.go
+++ b/internal/app/preflight.go
@@ -89,7 +89,7 @@ func validateLiveModel(
 		if !isOfficialDeepSeek(model) || model.APIKeyEnv != deepSeekAPIKey {
 			return liveValidationFailure(model, liveValidationConfigurationInvalid, 0)
 		}
-	case "sglang":
+	case "sglang", "openai":
 	default:
 		return liveValidationFailure(model, liveValidationConfigurationInvalid, 0)
 	}
@@ -105,8 +105,8 @@ func validateLiveModel(
 	if len(key) == 0 || len(key) > maxAPIKeyBytes || bytes.ContainsAny(key, "\x00\r\n") {
 		return liveValidationFailure(model, liveValidationCredentialInvalid, 0)
 	}
-	if model.Provider == "sglang" {
-		return validateSGLangModel(ctx, model, key, client)
+	if model.Provider == "sglang" || model.Provider == "openai" {
+		return validateOpenAICompatibleModel(ctx, model, key, client)
 	}
 	if client == nil {
 		client = newDeepSeekHTTPClient()
@@ -139,7 +139,11 @@ func (transport doerTransport) RoundTrip(request *http.Request) (*http.Response,
 	return transport.doer.Do(request)
 }
 
-func validateSGLangModel(ctx context.Context, model core.ModelConfig, key []byte, doer httpDoer) (liveValidation, error) {
+// validateOpenAICompatibleModel performs one bounded GET on the server's
+// /v1/models listing and confirms the configured model ID is served. SGLang
+// and every other OpenAI-compatible server share this path; the recorded
+// provider is the profile's backend name.
+func validateOpenAICompatibleModel(ctx context.Context, model core.ModelConfig, key []byte, doer httpDoer) (liveValidation, error) {
 	var httpClient *http.Client
 	if doer != nil {
 		httpClient = &http.Client{Timeout: deepSeekRequestTimeout, Transport: doerTransport{doer: doer}}
@@ -185,7 +189,7 @@ func validateSGLangModel(ctx context.Context, model core.ModelConfig, key []byte
 	}
 	for _, candidate := range models {
 		if candidate == model.Model {
-			return liveValidation{SchemaVersion: 1, Status: liveValidationSucceeded, Category: liveValidationConfirmed, Provider: "sglang", BaseURL: model.BaseURL, Model: model.Model, Attempts: 1}, nil
+			return liveValidation{SchemaVersion: 1, Status: liveValidationSucceeded, Category: liveValidationConfirmed, Provider: model.Provider, BaseURL: model.BaseURL, Model: model.Model, Attempts: 1}, nil
 		}
 	}
 	return liveValidationFailure(model, liveValidationModelMissing, 1)

--- a/internal/app/preflight_test.go
+++ b/internal/app/preflight_test.go
@@ -437,3 +437,19 @@ func errString(err error) string {
 	}
 	return err.Error()
 }
+
+// A generic OpenAI-compatible server takes the same bounded /v1/models path as
+// SGLang, and the recorded provider stays the profile's backend name.
+func TestOpenAIPreflightUsesModelListingAndKeepsBackendName(t *testing.T) {
+	model := core.ModelConfig{Provider: "openai", BaseURL: "http://fake.invalid/v1", Model: "served/model", APIKeyEnv: "VLLM_API_KEY"}
+	doer := &sglangPreflightDoer{t: t, wantURL: "http://fake.invalid/v1/models", body: `{"data":[{"id":"served/model"}]}`}
+	validation, err := validateLiveModel(context.Background(), model, func(string) ([]byte, bool) { return []byte("dummy"), true }, doer, nil)
+	if err != nil || validation.Provider != "openai" || validation.Status != liveValidationSucceeded || validation.Attempts != 1 || doer.authorization != "Bearer dummy" {
+		t.Fatalf("validation=%+v auth=%q error=%v", validation, doer.authorization, err)
+	}
+	doer = &sglangPreflightDoer{t: t, wantURL: "http://fake.invalid/v1/models", body: `{"data":[{"id":"other"}]}`}
+	validation, err = validateLiveModel(context.Background(), model, func(string) ([]byte, bool) { return []byte("dummy"), true }, doer, nil)
+	if err == nil || validation.Category != liveValidationModelMissing || validation.Provider != "openai" {
+		t.Fatalf("validation=%+v error=%v", validation, err)
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -44,6 +44,11 @@ type ExecutionConfig struct {
 	Loop         time.Duration `json:"-"`
 }
 
+// RuntimeConfig selects the model service. Backend "deepseek" and "openai"
+// are external only: "deepseek" is the official DeepSeek endpoint with its own
+// preflight, "openai" is any OpenAI-compatible server (vLLM, llama.cpp, a
+// gateway) that ARIES neither starts nor configures. Backend "sglang" may be
+// external or managed and carries a native YAML file either way.
 type RuntimeConfig struct {
 	Backend string              `json:"backend"`
 	Mode    string              `json:"mode"`
@@ -464,8 +469,8 @@ func (c *Config) validate() error {
 			return fmt.Errorf("%s is required", check.name)
 		}
 	}
-	if c.Runtime.Backend != "deepseek" && c.Runtime.Backend != "sglang" {
-		return errors.New("runtime.backend must be deepseek or sglang")
+	if c.Runtime.Backend != "deepseek" && c.Runtime.Backend != "sglang" && c.Runtime.Backend != "openai" {
+		return errors.New("runtime.backend must be deepseek, sglang, or openai")
 	}
 	if c.Harness.Mode == "" {
 		c.Harness.Mode = "agent"
@@ -488,10 +493,10 @@ func (c *Config) validate() error {
 		}
 	}
 
-	if c.Runtime.Backend == "sglang" {
-		normalized, err := normalizeSGLangBaseURL(c.Model.BaseURL)
+	if c.Runtime.Backend == "sglang" || c.Runtime.Backend == "openai" {
+		normalized, err := normalizeV1BaseURL(c.Model.BaseURL)
 		if err != nil {
-			return fmt.Errorf("model.base_url for sglang: %w", err)
+			return fmt.Errorf("model.base_url for %s: %w", c.Runtime.Backend, err)
 		}
 		c.Model.BaseURL = normalized
 	} else if err := validateHTTPBaseURL("model.base_url", c.Model.BaseURL); err != nil {
@@ -708,17 +713,17 @@ func parseOptionalPositiveDuration(name, value string) (time.Duration, error) {
 
 func (c *RuntimeConfig) validate() error {
 	switch c.Backend {
-	case "deepseek":
+	case "deepseek", "openai":
 		if c.Mode != "external" {
-			return errors.New("runtime.backend deepseek requires external mode")
+			return fmt.Errorf("runtime.backend %s requires external mode", c.Backend)
 		}
 		if c.Config.File != "" || c.Config.Executable != "" || c.Config.StartupTimeoutText != "" || c.Config.StopTimeoutText != "" || len(c.Config.GPUIndices) != 0 {
-			return errors.New("external deepseek runtime.config must be empty")
+			return fmt.Errorf("external %s runtime.config must be empty", c.Backend)
 		}
 		return nil
 	case "sglang":
 	default:
-		return errors.New("runtime.backend must be deepseek or sglang")
+		return errors.New("runtime.backend must be deepseek, sglang, or openai")
 	}
 	switch c.Mode {
 	case "external":
@@ -761,7 +766,9 @@ func (c *RuntimeConfig) validate() error {
 	}
 }
 
-func normalizeSGLangBaseURL(baseURL string) (string, error) {
+// normalizeV1BaseURL accepts the base URL of an OpenAI-compatible server: an
+// absolute HTTP(S) URL whose path is exactly the versioned /v1 prefix.
+func normalizeV1BaseURL(baseURL string) (string, error) {
 	parsed, err := url.Parse(baseURL)
 	if err != nil || parsed.Scheme != "http" && parsed.Scheme != "https" || parsed.Host == "" || parsed.Opaque != "" || parsed.User != nil || parsed.RawPath != "" || parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" || strings.Contains(baseURL, "#") {
 		return "", errors.New("must be an absolute HTTP(S) URL without credentials, escaped path, query, or fragment")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -44,11 +44,15 @@ type ExecutionConfig struct {
 	Loop         time.Duration `json:"-"`
 }
 
-// RuntimeConfig selects the model service. Backend "deepseek" and "openai"
-// are external only: "deepseek" is the official DeepSeek endpoint with its own
-// preflight, "openai" is any OpenAI-compatible server (vLLM, llama.cpp, a
-// gateway) that ARIES neither starts nor configures. Backend "sglang" may be
-// external or managed and carries a native YAML file either way.
+// RuntimeConfig selects the model service. Mode is the ownership distinction:
+// "external" is an endpoint ARIES validates but never starts, configures, or
+// stops; "managed" is a host process ARIES owns for the run. Backend names the
+// kind of service behind the endpoint, not a runtime ARIES prepares: it
+// selects the preflight and the provider each harness renders. "deepseek" is
+// the official DeepSeek endpoint with its own preflight; "openai" is any other
+// OpenAI-compatible server (vLLM, llama.cpp, a gateway) with generic /v1/models
+// discovery; both are external only. "sglang" shares that discovery, may be
+// external or managed, and carries a native YAML file either way.
 type RuntimeConfig struct {
 	Backend string              `json:"backend"`
 	Mode    string              `json:"mode"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -52,7 +52,7 @@ type ExecutionConfig struct {
 // the official DeepSeek endpoint with its own preflight; "openai" is any other
 // OpenAI-compatible server (vLLM, llama.cpp, a gateway) with generic /v1/models
 // discovery; both are external only. "sglang" shares that discovery, may be
-// external or managed, and carries a native YAML file either way.
+// external or managed; only managed mode requires a native YAML launch file.
 type RuntimeConfig struct {
 	Backend string              `json:"backend"`
 	Mode    string              `json:"mode"`
@@ -731,9 +731,6 @@ func (c *RuntimeConfig) validate() error {
 	}
 	switch c.Mode {
 	case "external":
-		if strings.TrimSpace(c.Config.File) == "" {
-			return errors.New("external SGLang runtime.config.file is required")
-		}
 		if c.Config.Executable != "" || c.Config.StartupTimeoutText != "" || c.Config.StopTimeoutText != "" || len(c.Config.GPUIndices) != 0 {
 			return errors.New("external SGLang runtime.config must not set executable, timeouts, or gpu_indices")
 		}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -489,7 +489,7 @@ func TestCheckedInProfilesLoad(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(paths) != 11 {
+	if len(paths) != 12 {
 		t.Fatalf("profiles=%v", paths)
 	}
 	for _, path := range paths {
@@ -635,5 +635,27 @@ func TestBridgeRawLogDefaultsToDropped(t *testing.T) {
 	}
 	if !enabled.RetainBridgeRawLog() {
 		t.Fatal("retain_raw_log:true must retain the raw log")
+	}
+}
+
+// The openai backend names any OpenAI-compatible server. It is external only,
+// carries no native configuration, and shares the /v1 base URL rule.
+func TestOpenAIBackendIsExternalOnly(t *testing.T) {
+	openai := strings.Replace(validConfig, `"runtime":{"backend":"deepseek","mode":"external"}`, `"runtime":{"backend":"openai","mode":"external"}`, 1)
+	openai = strings.Replace(openai, `http://127.0.0.1:8080`, `http://vllm.local:8000/v1/`, 1)
+	cfg, err := Decode(strings.NewReader(openai))
+	if err != nil || cfg.Model.BaseURL != "http://vllm.local:8000/v1" || cfg.CoreModel().Provider != "openai" {
+		t.Fatalf("url=%q provider=%q err=%v", cfg.Model.BaseURL, cfg.CoreModel().Provider, err)
+	}
+	rejected := map[string]string{
+		"managed mode":    strings.Replace(openai, `"mode":"external"`, `"mode":"managed"`, 1),
+		"native file":     strings.Replace(openai, `"mode":"external"`, `"mode":"external","config":{"file":"native.yaml"}`, 1),
+		"path without v1": strings.Replace(openai, `http://vllm.local:8000/v1/`, `http://vllm.local:8000`, 1),
+		"unknown backend": strings.Replace(openai, `"backend":"openai"`, `"backend":"vllm"`, 1),
+	}
+	for name, text := range rejected {
+		if _, err := Decode(strings.NewReader(text)); err == nil {
+			t.Fatalf("%s: expected rejection", name)
+		}
 	}
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -45,6 +45,10 @@ func TestNormalizedRuntimeSchema(t *testing.T) {
 	if _, err := Decode(strings.NewReader(external)); err != nil {
 		t.Fatal(err)
 	}
+	external = strings.Replace(external, `,"config":{"file":"native.yaml"}`, "", 1)
+	if _, err := Decode(strings.NewReader(external)); err != nil {
+		t.Fatalf("external SGLang without native config: %v", err)
+	}
 }
 
 func TestRealtimeHarnessConfigValidationAndResolution(t *testing.T) {

--- a/pkg/harness/hermes/config.go
+++ b/pkg/harness/hermes/config.go
@@ -38,6 +38,27 @@ const (
 	searxngBaseURL = "http://task-sandbox:8888"
 )
 
+// hermesProvider maps the profile's runtime backend onto a provider name
+// Hermes accepts. "deepseek" is a built-in Hermes provider. Neither pinned
+// Hermes version knows "sglang" or a plain "openai" provider
+// (hermes_cli/auth.py PROVIDER_REGISTRY), and the one-shot rejects an unknown
+// name before any request is made. The generic "custom" provider is the one
+// that routes to model.base_url with the configured key, so every
+// OpenAI-compatible backend renders as "custom". The same value is passed to
+// the one-shot as --provider, so the wrapper and the config never disagree.
+func hermesProvider(backend string) string {
+	if openAICompatible(backend) {
+		return "custom"
+	}
+	return backend
+}
+
+// openAICompatible reports whether the backend is a generic OpenAI-compatible
+// server whose base URL must be the versioned /v1 prefix.
+func openAICompatible(provider string) bool {
+	return provider == "sglang" || provider == "openai"
+}
+
 // renderConfig produces the Hermes `config.yaml`. The credential is written as
 // a ${NAME} reference rather than a value: Hermes expands those from the process
 // environment (hermes_cli/config.py::_expand_env_vars), and the wrapper script
@@ -51,10 +72,10 @@ func renderConfig(model core.ModelConfig, maxTurns int, webSearchEnabled, extrac
 	if err := validateModel(model); err != nil {
 		return nil, err
 	}
-	if model.Provider == "sglang" {
-		normalized, err := normalizeSGLangBaseURL(model.BaseURL)
+	if openAICompatible(model.Provider) {
+		normalized, err := normalizeV1BaseURL(model.BaseURL)
 		if err != nil {
-			return nil, fmt.Errorf("Hermes SGLang base URL: %w", err)
+			return nil, fmt.Errorf("Hermes %s base URL: %w", model.Provider, err)
 		}
 		model.BaseURL = normalized
 	}
@@ -64,7 +85,7 @@ func renderConfig(model core.ModelConfig, maxTurns int, webSearchEnabled, extrac
 	var output bytes.Buffer
 	output.WriteString("model:\n")
 	output.WriteString("  default: " + yamlString(model.Model) + "\n")
-	output.WriteString("  provider: " + yamlString(model.Provider) + "\n")
+	output.WriteString("  provider: " + yamlString(hermesProvider(model.Provider)) + "\n")
 	output.WriteString("  base_url: " + yamlString(model.BaseURL) + "\n")
 	output.WriteString("  api_key: " + yamlString("${"+model.APIKeyEnv+"}") + "\n")
 	output.WriteString("  api_mode: \"chat_completions\"\n")
@@ -181,12 +202,12 @@ export ` + tavilyAPIKeyEnv + `
 }
 
 func validateModel(model core.ModelConfig) error {
-	if model.Provider != "deepseek" && model.Provider != "sglang" {
-		return errors.New("Hermes model provider must be deepseek or sglang")
+	if model.Provider != "deepseek" && !openAICompatible(model.Provider) {
+		return errors.New("Hermes model provider must be deepseek, sglang, or openai")
 	}
-	if model.Provider == "sglang" {
-		if _, err := normalizeSGLangBaseURL(model.BaseURL); err != nil {
-			return fmt.Errorf("Hermes SGLang base URL: %w", err)
+	if openAICompatible(model.Provider) {
+		if _, err := normalizeV1BaseURL(model.BaseURL); err != nil {
+			return fmt.Errorf("Hermes %s base URL: %w", model.Provider, err)
 		}
 	} else {
 		parsed, err := url.Parse(model.BaseURL)
@@ -210,7 +231,7 @@ func validateModel(model core.ModelConfig) error {
 	return nil
 }
 
-func normalizeSGLangBaseURL(baseURL string) (string, error) {
+func normalizeV1BaseURL(baseURL string) (string, error) {
 	parsed, err := url.Parse(baseURL)
 	if err != nil || parsed.Scheme != "http" && parsed.Scheme != "https" || parsed.Host == "" || parsed.Opaque != "" || parsed.User != nil || parsed.RawPath != "" || parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" || strings.Contains(baseURL, "#") {
 		return "", errors.New("must be an absolute HTTP(S) URL without credentials, escaped path, query, or fragment")

--- a/pkg/harness/hermes/config_test.go
+++ b/pkg/harness/hermes/config_test.go
@@ -51,7 +51,7 @@ func TestRenderConfigNormalizesSGLangAndRejectsBadInput(t *testing.T) {
 		t.Fatalf("SGLang base URL was not normalized:\n%s", rendered)
 	}
 	bad := map[string]func(*core.ModelConfig){
-		"provider":  func(m *core.ModelConfig) { m.Provider = "openai" },
+		"provider":  func(m *core.ModelConfig) { m.Provider = "anthropic" },
 		"base url":  func(m *core.ModelConfig) { m.BaseURL = "ftp://host" },
 		"model id":  func(m *core.ModelConfig) { m.Model = " " },
 		"key env":   func(m *core.ModelConfig) { m.APIKeyEnv = "1BAD" },
@@ -363,5 +363,34 @@ func TestAgentWrapperExportsExtractKeyWhenEnabled(t *testing.T) {
 		if !strings.Contains(script, want) {
 			t.Fatalf("wrapper is missing %q:\n%s", want, script)
 		}
+	}
+}
+
+// Neither pinned Hermes version knows an "sglang" or plain "openai" provider,
+// and the one-shot rejects an unknown name, so both backends must render as
+// Hermes's generic "custom" provider. DeepSeek is built in and stays as written.
+func TestRenderConfigMapsOpenAICompatibleBackendsToCustomProvider(t *testing.T) {
+	for _, provider := range []string{"sglang", "openai"} {
+		model := validModel()
+		model.Provider = provider
+		model.BaseURL = "http://vllm.local:8000/v1"
+		rendered, err := renderConfig(model, 10, false, false, true, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		text := string(rendered)
+		if !strings.Contains(text, `provider: "custom"`) || strings.Contains(text, `provider: "`+provider+`"`) {
+			t.Fatalf("%s backend was not rendered as the custom provider:\n%s", provider, text)
+		}
+		if got := hermesProvider(provider); got != "custom" {
+			t.Fatalf("hermesProvider(%s) = %q", provider, got)
+		}
+	}
+	rendered, err := renderConfig(validModel(), 10, false, false, true, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(rendered), `provider: "deepseek"`) || hermesProvider("deepseek") != "deepseek" {
+		t.Fatal("deepseek provider was rewritten")
 	}
 }

--- a/pkg/harness/hermes/harness.go
+++ b/pkg/harness/hermes/harness.go
@@ -435,7 +435,7 @@ func (manager *Manager) Run(ctx context.Context, instruction string) (core.Harne
 
 	runCtx, cancel := context.WithTimeout(ctx, active.agentTimeout)
 	result, runErr := manager.execAttached(runCtx, active.containerID,
-		[]string{agentWrapperPath, active.model.Model, active.model.Provider, instruction}, workspaceRoot)
+		[]string{agentWrapperPath, active.model.Model, hermesProvider(active.model.Provider), instruction}, workspaceRoot)
 	cancel()
 
 	stdout := redactSession(result.stdout, active)

--- a/pkg/harness/openclaw/config.go
+++ b/pkg/harness/openclaw/config.go
@@ -164,15 +164,19 @@ func renderConfig(model core.ModelConfig, endpoint core.ToolEndpoint, webSearchE
 	if err := validateModel(model); err != nil {
 		return nil, err
 	}
-	if model.Provider == "sglang" {
-		model.BaseURL, _ = normalizeSGLangBaseURL(model.BaseURL)
+	if openAICompatible(model.Provider) {
+		model.BaseURL, _ = normalizeV1BaseURL(model.BaseURL)
 	}
 	if err := validateEndpoint(endpoint); err != nil {
 		return nil, err
 	}
-	providerID := model.Provider
-	if providerID == "deepseek" {
-		providerID = "aries"
+	// providerID keys the models.providers entry OpenClaw merges into its
+	// catalog. DeepSeek and generic OpenAI-compatible servers use the neutral
+	// "aries" id so the entry never collides with a built-in provider of the
+	// same name; SGLang keeps its own id.
+	providerID := "aries"
+	if model.Provider == "sglang" {
+		providerID = "sglang"
 	}
 	configuration := openClawConfig{
 		Gateway: gatewayConfig{
@@ -256,12 +260,12 @@ func denyToolList(subagentsEnabled bool) []string {
 }
 
 func validateModel(model core.ModelConfig) error {
-	if model.Provider != "deepseek" && model.Provider != "sglang" {
-		return errors.New("OpenClaw model provider must be deepseek or sglang")
+	if model.Provider != "deepseek" && !openAICompatible(model.Provider) {
+		return errors.New("OpenClaw model provider must be deepseek, sglang, or openai")
 	}
-	if model.Provider == "sglang" {
-		if _, err := normalizeSGLangBaseURL(model.BaseURL); err != nil {
-			return fmt.Errorf("OpenClaw SGLang base URL: %w", err)
+	if openAICompatible(model.Provider) {
+		if _, err := normalizeV1BaseURL(model.BaseURL); err != nil {
+			return fmt.Errorf("OpenClaw %s base URL: %w", model.Provider, err)
 		}
 	} else {
 		parsed, err := url.Parse(model.BaseURL)
@@ -281,7 +285,13 @@ func validateModel(model core.ModelConfig) error {
 	return nil
 }
 
-func normalizeSGLangBaseURL(baseURL string) (string, error) {
+// openAICompatible reports whether the backend is a generic OpenAI-compatible
+// server whose base URL must be the versioned /v1 prefix.
+func openAICompatible(provider string) bool {
+	return provider == "sglang" || provider == "openai"
+}
+
+func normalizeV1BaseURL(baseURL string) (string, error) {
 	parsed, err := url.Parse(baseURL)
 	if err != nil || parsed.Scheme != "http" && parsed.Scheme != "https" || parsed.Host == "" || parsed.Opaque != "" || parsed.User != nil || parsed.RawPath != "" || parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" || strings.Contains(baseURL, "#") {
 		return "", errors.New("must be an absolute HTTP(S) URL without credentials, escaped path, query, or fragment")

--- a/pkg/harness/openclaw/config_test.go
+++ b/pkg/harness/openclaw/config_test.go
@@ -309,3 +309,28 @@ func TestLauncherExportsTavilyKeyWhenExtractEnabled(t *testing.T) {
 		t.Fatalf("launcher exports tavily key when extract is disabled: %s", disabledScript)
 	}
 }
+
+// A generic OpenAI-compatible server is keyed under the neutral "aries"
+// provider id, like DeepSeek, and its base URL follows the /v1 rule.
+func TestRenderConfigKeysOpenAICompatibleProviderAsAries(t *testing.T) {
+	model := testModel()
+	model.Provider = "openai"
+	model.BaseURL = "http://vllm.local:8000/v1/"
+	model.APIKeyEnv = "VLLM_API_KEY"
+	content, err := renderConfig(model, testEndpoint(), false, false, false, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var configuration openClawConfig
+	if err := json.Unmarshal(content, &configuration); err != nil {
+		t.Fatal(err)
+	}
+	provider, ok := configuration.Models.Providers["aries"]
+	if !ok || len(configuration.Models.Providers) != 1 || provider.BaseURL != "http://vllm.local:8000/v1" || provider.APIKey != "${VLLM_API_KEY}" || configuration.Agents.Defaults.Model.Primary != "aries/deterministic-model" {
+		t.Fatalf("configuration = %#v", configuration)
+	}
+	model.BaseURL = "http://vllm.local:8000"
+	if _, err := renderConfig(model, testEndpoint(), false, false, false, 0); err == nil {
+		t.Fatal("accepted an openai base URL without /v1")
+	}
+}

--- a/profiles/hermes-tb2-fix-git-vllm.json
+++ b/profiles/hermes-tb2-fix-git-vllm.json
@@ -1,0 +1,34 @@
+{
+  "name": "hermes-tb2-fix-git-vllm",
+  "versions_file": "../configs/versions.json",
+  "overrides_file": "",
+  "execution": {
+    "concurrency": 1
+  },
+  "benchmark": {
+    "type": "terminalbench2",
+    "root": ".cache/terminal-bench-2",
+    "tasks": [
+      "fix-git"
+    ]
+  },
+  "harness": {
+    "type": "hermes"
+  },
+  "sandbox": {
+    "type": "docker"
+  },
+  "bridge": {
+    "type": "hermes-ssh"
+  },
+  "runtime": {
+    "backend": "openai",
+    "mode": "external"
+  },
+  "model": {
+    "base_url": "http://vllm.local:8000/v1",
+    "api_key_env": "VLLM_API_KEY",
+    "id": "Qwen/Qwen3.6-35B-A3B-FP8"
+  },
+  "output_dir": "runs"
+}


### PR DESCRIPTION
## Summary

Add `runtime.backend: "openai"`: any OpenAI-compatible server (vLLM, llama.cpp, gateways, hosted endpoints) as an external-only model service, with no native configuration file.

## Implementation Notes :hammer_and_pick:

* `openai` is external only and takes no `runtime.config`, like `deepseek`. Its base URL follows the same `/v1` rule as SGLang.
* `runtime.mode` stays the ownership distinction and `runtime.backend` names the kind of service behind the endpoint, which selects the preflight and the harness provider mapping. `prepareBackend` now switches on the mode first: every external endpoint takes one path, and only managed SGLang is a runtime ARIES prepares, so `openai` adds no runtime branch. The design docs state the same split.
* Preflight reuses the bounded `/v1/models` discovery that external SGLang already performs. The recorded provider is the backend name.
* Hermes: neither pinned version has an `sglang` or plain `openai` provider (`hermes_cli/auth.py` `PROVIDER_REGISTRY`), and the one-shot rejects an unknown name before any request. Both backends now render as Hermes's generic `custom` provider in `config.yaml` and in the `--provider` argument. This also fixes the existing Hermes + SGLang combination.
* OpenClaw keys the server under the neutral `aries` provider id, as it already does for DeepSeek. SGLang keeps its id.
* New profile `profiles/hermes-tb2-fix-git-vllm.json`. Docs: quick start, supported table, runtime and harness design guides.

## External Dependencies :four_leaf_clover:

* None.

## Breaking API Changes :warning:

* None. Existing profiles decode unchanged. The Hermes + SGLang rendered provider changes from `sglang` (rejected by Hermes) to `custom`.

## Issues that this PR closes

* Refs #11 (external vLLM through an OpenAI-compatible backend; a managed vLLM runtime is out of scope here).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for external OpenAI-compatible model servers, including vLLM, llama.cpp, gateways, and hosted endpoints.
  - Added `/v1` model discovery and validation for OpenAI-compatible backends.
  - Added support for connecting these servers to Hermes and OpenClaw.
  - Added a Hermes profile for running TerminalBench 2 against a vLLM endpoint.

- **Documentation**
  - Updated setup guides, supported-platform information, and architecture documentation with configuration examples and usage details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
